### PR TITLE
Add Charr hazard fix to possible patch

### DIFF
--- a/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Charr.cfg
+++ b/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Charr.cfg
@@ -210,7 +210,7 @@
 			Item
 			{
 				ambientTemp = 2000
-				biomeName = Molten Craters
+				biomeName = MoltenCraters
 				AltitudeCurve
 				{
 					key = 493000 1.0 0.00000 -3.3E-4
@@ -225,7 +225,7 @@
 			Item
 			{
 				ambientTemp = 1200
-				biomeName = Hot Craters
+				biomeName = HotCraters
 				AltitudeCurve
 				{
 					key = 493000 1.0 0.00000 -3.3E-4


### PR DESCRIPTION
Charr's HazardousBody configs had a typo, causing Charr's Hot Craters and Molten Craters to be calm and tame. No longer! Charr's craters are now deadly as intended.