### PR TITLE
Re-add Debdeb system wormholes

### DIFF
--- a/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Wormholes/KAA.cfg
+++ b/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Wormholes/KAA.cfg
@@ -1,0 +1,174 @@
+@Kopernicus:FOR[PromisedWorlds]:HAS[@PromisedWorldsSettings:HAS[~Wormholes[?alse]]]:NEEDS[KopernicusExpansion]
+{
+	Body
+	{
+		name = Kevba's Anomaly A
+		identifier = PromisedWorlds/Kevba's Anomaly A
+		cacheFile = PromisedWorlds/Cache/KAA.bin
+		Tag = Debdeb_Wormhole
+		Template
+		{
+			name = Minmus
+			removeAllPQSMods = true
+		}
+		Properties
+		{
+			description = A mysterious wormhole at the edge of the Kerbolar system. We're not sure how it got there or what its purpose is... but why not capitalise on the opportunity for cheap interstellar travel?
+			radius = 10000
+			geeASL = 8
+			tidallyLocked = false
+			rotationPeriod = 50000
+			timewarpAltitudeLimits = 0 0 0 0 0 0 0 0
+			maxZoom = 60000
+			ScienceValues
+			{
+				landedDataValue = 5 // Science multiplier for landed science.
+				splashedDataValue = 1 // Science multiplier for splashed down science.
+				flyingLowDataValue = 1 // Science multiplier for flying low science.
+				flyingHighDataValue = 1 // Science multiplier for flying high science.
+				inSpaceLowDataValue = 4 // Science multiplier for in space low science.
+				inSpaceHighDataValue = 2.5 // Science multiplier for in space high science.
+				recoveryValue = 2.5
+				flyingAltitudeThreshold = 40000 // Altitude when "flying at <body>" transitions from/to "from <body>'s upper atmosphere"
+				spaceAltitudeThreshold = 60000 // Altitude when "in space low" transitions from/to "in space high"
+			}
+			biomeMap = PromisedWorlds/_Systems/Debdeb/PluginData/Black.png
+			Biomes
+			{
+				Biome
+				{
+					name = Wormhole
+					displayName = Wormhole
+					value = 0
+					color = #000000
+				}
+			}
+		}
+		Wormhole
+		{
+			partner = Kevba's Anomaly B
+			influenceAltitude = 35000
+			jumpMaxAltitude = 30000
+			jumpMinAltitude = 10
+			entryMessage = Entering the anomaly...
+			exitMessage = Arriving at the Kerbolar system
+			entryMsgDuration = 20
+			exitMsgDuration = 10
+			heatRate = 0.01
+		}
+		ScaledVersion
+		{
+			type = Vacuum
+			fadeStart = 7000
+			fadeEnd = 10000
+			OnDemand
+			{	
+				texture = PromisedWorlds/_Systems/Debdeb/PluginData/Black.png
+				normals = PromisedWorlds/_Systems/Debdeb/PluginData/Blank_Normal.dds
+			}
+			Material
+			{
+				color = 1,1,1,1
+				specColor = 0.05,0.05,0.05,1
+				shininess = 1
+				
+			}
+		}
+		Orbit
+		{
+			referenceBody = Eeloo
+			inclination = 0
+			eccentricity = 0
+			semiMajorAxis = 21210000
+			longitudeOfAscendingNode = 78
+			argumentOfPeriapsis = 38
+			epoch = 0
+			color = 0.2,0.2,0.2,0.2
+		}
+		
+		PQS
+		{
+			Mods
+			{			
+				VertexHeightMap
+				{
+					map = PromisedWorlds/_Systems/Debdeb/PluginData/Black.png
+					offset = -9999
+					deformity = 0
+					scaleDeformityByRadius = False
+					order = 10
+					enabled = True
+				}
+				VertexColorMap
+				{
+					map = PromisedWorlds/_Systems/Debdeb/PluginData/Black.png
+					order = 90
+					enabled = True
+					name = VertexColorMap
+					index = 0
+				} 
+			}
+		}
+		
+	}
+}
+
+@Kopernicus:AFTER[OPM]
+{
+	@Body[Kevba's?Anomaly?A]
+	{
+		@Orbit
+		{
+			%referenceBody = Plock
+			%semiMajorAxis = 31210000
+		}
+	}
+}
+
+@Kopernicus:AFTER[CelestialHarmony]
+{
+	@Body[Kevba's?Anomaly?A]
+	{
+		@Orbit
+		{
+			%referenceBody = Gaia
+			%semiMajorAxis = 20940790
+		}
+	}
+}
+
+@Kopernicus:AFTER[RealSolarSystem]
+{
+	@Body[WH3141A]
+	{
+		@Orbit
+		{
+			%referenceBody = Pluto
+			%semiMajorAxis = 98765000
+		}
+	}
+}
+
+@Kopernicus:AFTER[KSRSS]
+{
+	@Body[WH3141A]
+	{
+		@Orbit
+		{
+			%referenceBody = Pluto
+			%semiMajorAxis = 98765000
+		}
+	}
+}
+
+@Kopernicus:LAST[Kopernicus]:HAS[!Body[Eeloo]]:NEEDS[!RealSolarSystem,!KSRSS]
+{
+	@Body[WH3141A]
+	{
+		@Orbit
+		{
+			%referenceBody = Sun
+			%semiMajorAxis = 5.329834E10
+		}
+	}
+}

--- a/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Wormholes/KAB.cfg
+++ b/GameData/PromisedWorlds/_Systems/Debdeb/Configs/Wormholes/KAB.cfg
@@ -1,0 +1,115 @@
+
+@Kopernicus:FOR[PromisedWorlds]:HAS[@PromisedWorldsSettings:HAS[~Wormholes[?alse]]]:NEEDS[KopernicusExpansion]
+{
+	Body
+	{
+		name = Kevba's Anomaly B
+		identifier = PromisedWorlds/Kevba's Anomaly B
+		cacheFile = PromisedWorlds/Cache/KAB.bin
+		Tag = Kerbol_Wormhole
+		Template
+		{
+			name = Minmus
+			removeAllPQSMods = true
+		}
+		Properties
+		{
+			description = The entrance to the Debdeb system, with a stunning view!
+			radius = 10000
+			geeASL = 8
+			tidallyLocked = false
+			rotationPeriod = 50000
+			timewarpAltitudeLimits = 0 0 0 0 0 0 0 0
+			maxZoom = 60000
+			ScienceValues
+			{
+				landedDataValue = 5 // Science multiplier for landed science.
+				splashedDataValue = 1 // Science multiplier for splashed down science.
+				flyingLowDataValue = 1 // Science multiplier for flying low science.
+				flyingHighDataValue = 1 // Science multiplier for flying high science.
+				inSpaceLowDataValue = 4 // Science multiplier for in space low science.
+				inSpaceHighDataValue = 2.5 // Science multiplier for in space high science.
+				recoveryValue = 2.5
+				flyingAltitudeThreshold = 40000 // Altitude when "flying at <body>" transitions from/to "from <body>'s upper atmosphere"
+				spaceAltitudeThreshold = 60000 // Altitude when "in space low" transitions from/to "in space high"
+			}
+			biomeMap = PromisedWorlds/_Systems/Debdeb/PluginData/Black.png
+			Biomes
+			{
+				Biome
+				{
+					name = Wormhole
+					displayName = Wormhole
+					value = 0
+					color = #000000
+				}
+			}
+		}
+		Wormhole
+		{
+			partner = Kevba's Anomaly A
+			influenceAltitude = 35000
+			jumpMaxAltitude = 30000
+			jumpMinAltitude = 10
+			entryMessage = Entering the anomaly...
+			exitMessage = Arriving at the Debdeb system
+			entryMsgDuration = 20
+			exitMsgDuration = 10
+			heatRate = 0.01
+		}
+		ScaledVersion
+		{
+			type = Vacuum
+			fadeStart = 7000
+			fadeEnd = 10000
+			OnDemand
+			{	
+				texture = PromisedWorlds/_Systems/Debdeb/PluginData/Black.png
+				normals = PromisedWorlds/_Systems/Debdeb/PluginData/Blank_Normal.dds
+			}
+			Material
+			{
+				color = 1,1,1,1
+				specColor = 0.05,0.05,0.05,1
+				shininess = 1
+				
+			}
+		}
+		Orbit
+		{
+			referenceBody = Gurdamma
+			inclination = 25
+			eccentricity = 0
+			semiMajorAxis = 6545200
+			longitudeOfAscendingNode = 78
+			argumentOfPeriapsis = 38
+			epoch = 0
+			color = 0.2,0.2,0.2,0.2
+		}
+		
+		PQS
+		{
+			Mods
+			{			
+				VertexHeightMap
+				{
+					map = PromisedWorlds/_Systems/Debdeb/PluginData/Black.png
+					offset = -9999
+					deformity = 0
+					scaleDeformityByRadius = False
+					order = 10
+					enabled = True
+				}
+				VertexColorMap
+				{
+					map = PromisedWorlds/_Systems/Debdeb/PluginData/Black.png
+					order = 90
+					enabled = True
+					name = VertexColorMap
+					index = 0
+				} 
+			}
+		}
+		
+	}
+}


### PR DESCRIPTION
The Debdeb system wormholes were mistakenly removed in v1.0.1, this puts them back, which will be good for casual players who may not want to build massive ISVs.